### PR TITLE
немного улучшаем лаваленд

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_elite_tumor.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_elite_tumor.dmm
@@ -9,6 +9,13 @@
 "c" = (
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"H" = (
+/obj/item/organ/monster_core/regenerative_core/legion{
+	time_to_decay = 1
+	},
+/obj/effect/mob_spawn/corpse/human/legioninfested/skeleton/charred,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 
 (1,1,1) = {"
 a
@@ -70,7 +77,7 @@ a
 a
 a
 c
-c
+H
 c
 a
 a

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -9,19 +9,28 @@
 /turf/closed/wall/r_wall,
 /area/ruin/powered/seedvault)
 "ad" = (
-/obj/machinery/vending/hydronutrients,
+/obj/item/gun/energy/floragun{
+	pixel_y = 6
+	},
+/obj/item/gun/energy/floragun{
+	pixel_y = 4
+	},
+/obj/item/gun/energy/floragun{
+	pixel_y = 2
+	},
+/obj/item/gun/energy/floragun,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/turf_decal/trimline/green/filled/line,
+/obj/structure/closet/crate/hydroponics,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "ae" = (
-/obj/machinery/smartfridge,
-/obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"af" = (
-/obj/machinery/vending/hydroseeds,
-/obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/iron/dark,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/clothing/under/rank/civilian/hydroponics,
+/obj/item/clothing/under/rank/civilian/hydroponics,
+/obj/item/clothing/under/rank/civilian/hydroponics,
+/obj/item/clothing/under/rank/civilian/hydroponics,
+/turf/open/floor/iron/freezer,
 /area/ruin/powered/seedvault)
 "ag" = (
 /obj/structure/table/wood,
@@ -36,28 +45,15 @@
 /turf/open/floor/iron/freezer,
 /area/ruin/powered/seedvault)
 "ai" = (
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
 /obj/structure/table/wood,
 /obj/effect/turf_decal/trimline/green/filled/line,
+/obj/item/storage/box/beakers/bluespace{
+	pixel_y = 6
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "aj" = (
-/obj/structure/table/wood,
-/obj/item/gun/energy/floragun{
-	pixel_y = 6
-	},
-/obj/item/gun/energy/floragun{
-	pixel_y = 4
-	},
-/obj/item/gun/energy/floragun{
-	pixel_y = 2
-	},
-/obj/item/gun/energy/floragun,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/machinery/smartfridge/drying/rack,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "al" = (
@@ -76,16 +72,14 @@
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "ar" = (
+/obj/machinery/light/directional/east,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/storage/backpack/botany,
+/obj/item/storage/backpack/botany,
+/obj/item/storage/backpack/botany,
+/obj/item/storage/backpack/botany,
 /obj/structure/closet/crate/hydroponics,
-/obj/item/clothing/under/rank/civilian/hydroponics,
-/obj/item/clothing/under/rank/civilian/hydroponics,
-/obj/item/clothing/under/rank/civilian/hydroponics,
-/obj/item/clothing/under/rank/civilian/hydroponics,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/freezer,
 /area/ruin/powered/seedvault)
 "as" = (
 /obj/machinery/door/airlock/multi_tile/public/glass,
@@ -182,16 +176,28 @@
 /area/ruin/powered/seedvault)
 "aF" = (
 /obj/structure/table/wood,
-/obj/item/lighter,
-/obj/item/lighter,
-/obj/item/storage/fancy/rollingpapers,
-/obj/item/storage/fancy/rollingpapers,
-/obj/item/storage/fancy/rollingpapers,
-/obj/item/storage/fancy/rollingpapers,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/construction/plumbing/service{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/construction/plumbing{
+	pixel_x = 2;
+	pixel_y = -5
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "aG" = (
-/turf/closed/mineral/volcanic/lava_land_surface,
+/obj/item/circuitboard/machine/chem_dispenser,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/item/stock_parts/servo/femto,
+/obj/item/stock_parts/capacitor/quadratic,
+/obj/item/stock_parts/power_store/cell/bluespace,
+/obj/item/stock_parts/matter_bin/bluespace,
+/obj/item/stock_parts/matter_bin/bluespace,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/iron/freezer,
 /area/ruin/powered/seedvault)
 "aH" = (
 /obj/machinery/door/airlock/vault,
@@ -361,6 +367,7 @@
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 1
 	},
+/obj/machinery/smartfridge,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "bf" = (
@@ -534,19 +541,25 @@
 /turf/open/floor/iron/freezer,
 /area/ruin/powered/seedvault)
 "ds" = (
-/obj/effect/mob_spawn/ghost_role/human/seed_vault,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/freezer,
+/obj/structure/table/wood,
+/obj/item/lighter,
+/obj/item/lighter,
+/obj/item/storage/fancy/rollingpapers,
+/obj/item/storage/fancy/rollingpapers,
+/obj/item/storage/fancy/rollingpapers,
+/obj/item/storage/fancy/rollingpapers,
+/obj/item/storage/fancy/rollingpapers,
+/obj/item/storage/fancy/rollingpapers,
+/obj/item/storage/fancy/rollingpapers,
+/obj/item/storage/fancy/rollingpapers,
+/obj/item/lighter,
+/obj/item/lighter,
+/turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "eq" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/closed/mineral/volcanic/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"hf" = (
-/obj/structure/sink/directional/east,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
 "le" = (
 /obj/structure/window/spawner/directional/south,
 /obj/structure/flora/bush/flowers_pp/style_random,
@@ -588,8 +601,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "rX" = (
-/obj/structure/sink/directional/east,
-/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/vending/hydronutrients,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "sv" = (
@@ -626,13 +638,17 @@
 /turf/open/floor/iron/freezer,
 /area/ruin/powered/seedvault)
 "Kq" = (
-/obj/structure/sink/directional/west,
+/obj/machinery/vending/hydroseeds,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "KF" = (
 /obj/machinery/door/airlock/titanium,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/vault,
+/area/ruin/powered/seedvault)
+"LU" = (
+/obj/structure/falsewall/reinforced,
+/turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "OE" = (
 /obj/effect/mob_spawn/ghost_role/human/seed_vault,
@@ -800,7 +816,7 @@ aa
 (7,1,1) = {"
 aa
 ac
-ds
+og
 ah
 ac
 PH
@@ -822,15 +838,15 @@ aa
 (8,1,1) = {"
 aa
 ac
-ac
-ac
+ar
+ae
 ac
 PH
 ah
 aS
 ac
 aG
-ac
+LU
 bh
 aN
 aN
@@ -844,9 +860,9 @@ aa
 (9,1,1) = {"
 ac
 ac
-ar
-at
-az
+ac
+ac
+ac
 PH
 ah
 aT
@@ -866,13 +882,13 @@ ac
 (10,1,1) = {"
 ac
 ad
-al
+an
 al
 al
 PH
 ah
 al
-hf
+al
 ac
 rX
 bb
@@ -887,7 +903,7 @@ ac
 "}
 (11,1,1) = {"
 ac
-ae
+at
 al
 Vn
 Bb
@@ -909,14 +925,14 @@ ac
 "}
 (12,1,1) = {"
 ac
-af
+az
 am
 al
 al
 PH
 ah
 al
-Kq
+al
 ac
 Kq
 bb
@@ -981,7 +997,7 @@ Vn
 Bb
 Bb
 ah
-aF
+ds
 ac
 aA
 ac


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Что мы собственно тут делаем 😎
небольшой ремап лавалендской ботаники чтобы удобнее там было
а еще добавлен скелет и испорченное ядро легиона возле туморов как подсказка что можно ядра совать в тумор
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Почему это надо 👍
~а почему это не надо~
qol
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Список изменений 📖

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: улучшена база лавалендских растениеводов
qol: добавлена подсказка к помещению ядра легиона в тумор
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
